### PR TITLE
changed rails root dir to /tmp

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join('/tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store


### PR DESCRIPTION
Changes rails root directory in the development environment from `tmp` to `/tmp`.

Previously the rails app would create cached worker data in the working directory which persisted across container runtimes.

Now the cached worker data is in a container directory which is not persisted between containers.